### PR TITLE
setup pypi ci/cd

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,117 @@
+name: Publish Python 🐍 distribution 📦 to PyPI and TestPyPI
+
+on: push
+
+jobs:
+  build:
+    name: Build distribution 📦
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-pypi:
+    name: >-
+      Publish Python 🐍 distribution 📦 to PyPI
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/rectified-flow  # Replace <package-name> with your PyPI project name
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: >-
+      Sign the Python 🐍 distribution 📦 with Sigstore
+      and upload them to GitHub Release
+    needs:
+    - publish-to-pypi
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write  # IMPORTANT: mandatory for making GitHub Releases
+      id-token: write  # IMPORTANT: mandatory for sigstore
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Sign the dists with Sigstore
+      uses: sigstore/gh-action-sigstore-python@v3.0.0
+      with:
+        inputs: >-
+          ./dist/*.tar.gz
+          ./dist/*.whl
+    - name: Create GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: >-
+        gh release create
+        '${{ github.ref_name }}'
+        --repo '${{ github.repository }}'
+        --notes ""
+    - name: Upload artifact signatures to GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      # Upload to GitHub Release using the `gh` CLI.
+      # `dist/` contains the built packages, and the
+      # sigstore-produced signatures and certificates.
+      run: >-
+        gh release upload
+        '${{ github.ref_name }}' dist/**
+        --repo '${{ github.repository }}'
+
+  publish-to-testpypi:
+    name: Publish Python 🐍 distribution 📦 to TestPyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/rectified-flow 
+
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/logo_new2.png" alt="Logo" style="width: 75%; height: auto;">
+<img src="https://github.com/lqiang67/rectified-flow/blob/main/assets/logo_new2.png?raw=true" alt="Logo" style="width: 75%; height: auto;">
 
 [![License](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE) 
 [![Blog](https://img.shields.io/badge/blog-blue)](https://rectifiedflow.github.io)
@@ -9,7 +9,7 @@
 
 ______________________________________________________________________
 
-<img src="assets/header.png" alt="Header" style="width: 100%; height: auto;">
+<img src="https://github.com/lqiang67/rectified-flow/blob/main/assets/header.png?raw=true" alt="Header" style="width: 100%; height: auto;">
 </div>
 
 
@@ -50,8 +50,13 @@ Whether you are a researcher exploring the frontiers of generative modeling, a s
 
 # Installation
 
-Please run the following commands in the given order to install the dependency.
+You can install the `rectified-flow` package using `pip`:
 
+```
+pip install rectified-flow
+```
+
+Alternatively, you can install the package from source. Please run the following commands in the given order to install the dependency.
 
 ```
 conda create -n rf python=3.10

--- a/rectified_flow/__init__.py
+++ b/rectified_flow/__init__.py
@@ -1,1 +1,3 @@
 name = "rectified_flow"
+
+from .rectified_flow import RectifiedFlow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
+# Please update setup.py when modifying this file
+
 accelerate>=1.2.0
-clip==0.2.0
+clip@https://github.com/openai/CLIP/tarball/master#egg=clip-1.0.0
 diffusers>=0.31.0
-matplotlib==3.9.3
+matplotlib>=3.9.3
 numpy
 packaging
 Pillow
@@ -13,3 +15,5 @@ timm>=1.0.12
 torch>=2.5.0
 torchvision>=0.20.0
 tqdm
+ipykernel
+nbformat>=4.2.0

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,12 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="rectified-flow",
-    version="0.1.0",
+    version="1.0.1",
     description="A PyTorch implementation of Rectified Flow and its variants.",
     long_description=long_description,
     long_description_content_type="text/markdown",
     author="Qiang Liu, Runlong Liao, Bo Liu, Xixi Hu",
-    author_email="lqiang@cs.utexas.edu",
+    author_email="rectifiedflow@gmail.com",
     url="https://github.com/lqiang67/rectified-flow",
     packages=find_packages(),
     python_requires=">=3.10",
@@ -20,4 +20,21 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
+    install_requires=[
+        "accelerate>=1.2.0",
+        "openai-clip==1.0.1",
+        "diffusers>=0.31.0",
+        "matplotlib>=3.9.3",
+        "numpy",
+        "packaging",
+        "Pillow",
+        "plotly",
+        "scikit_learn",
+        "scipy",
+        "sympy",
+        "timm>=1.0.12",
+        "torch>=2.5.0",
+        "torchvision>=0.20.0",
+        "tqdm"
+    ]
 )


### PR DESCRIPTION
This commit sets up automatic publishing to PyPI, allowing the users to directly install the package with 

```sh
pip install rectified-flow
```

Notes:

- Any commit on the main branch will trigger update the package on TestPyPI for testing purposes.
- To make a new release, please first change the version field in `setup.py`, create a commit, then run `git tag 1.x.x` and push to github. After pushing to Github with a tag, the package on PyPI will be automatically updated.
- First release will be created after the pull request being merged.

Image links in `README.md` has been changed to absolute links to be displayed correctly on PyPI.